### PR TITLE
Fullscreen popup element

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@flourish/popup",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flourish/popup",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Popup UI component",
   "main": "popup.js",
   "module": "src/index.js",

--- a/src/constrainer.js
+++ b/src/constrainer.js
@@ -36,11 +36,12 @@ export function Popup__getConstrainer() {
 };
 
 export function Popup__resizeConstrainer() {
-	// The element must be removed before we compute the dimensions, or
+	// The element must be hidden before we compute the dimensions, or
 	// it will affect those dimensions itself, with the effect that the
 	// constrainer can only grow and never shrink.
-	document.body.removeChild(constrainer);
+	var old_display = style.display;
+	style.display = "none";
 	style.width = document.documentElement.scrollWidth + "px";
 	style.height = document.documentElement.scrollHeight + "px";
-	document.body.appendChild(constrainer);
+	style.display = old_display;
 }

--- a/src/draw.js
+++ b/src/draw.js
@@ -58,7 +58,9 @@ export default function Popup_draw() {
 
 	s.display = "block";
 	content.style.maxWidth = maxContentWidth(cb) + "px";
-	content.innerHTML = popup._html;
+	if (popup._inner_html != popup._html) {
+		content.innerHTML = popup._inner_html = popup._html;
+	}
 	var content_box = content.getBoundingClientRect(),
 	    w, h;
 	do {

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -51,6 +51,29 @@ function setUpOverflowTest(id) {
 	popups[id] = popup;
 }
 
+function setUpFullscreenTest(id) {
+	var el = document.getElementById(id);
+	if (el == null) return console.error("Element #" + id + " not found!");
+
+	var popup = Popup().container(document.body);
+	var r = el.getBoundingClientRect();
+	popup.point(r.x + r.width/2, r.y + r.height/2)
+		.html('<video controls="" src="https://public.flourish.studio/uploads/86a2c8dc-18ab-4c14-a6ca-ae0f361abd35.mp4" style="width: 200px"></video>')
+		.draw();
+
+	window.addEventListener("resize", function() {
+		var r = el.getBoundingClientRect();
+		popup.point(r.x + r.width/2, r.y + r.height/2)
+			.draw();
+	});
+
+	document.querySelector("#fullscreen-test button").onclick = function() {
+		this.parentElement.requestFullscreen();
+	};
+
+	popups[id] = popup;
+}
+
 document.addEventListener("DOMContentLoaded", function() {
 	var much0 = muchText(0), much4 = muchText(4), much8 = muchText(8), much15 = muchText(15);
 	test("test1", much0);
@@ -65,4 +88,5 @@ document.addEventListener("DOMContentLoaded", function() {
 	test("test10", much8, function(popup) { popup.container(document.querySelector("#test10 .inner")); });
 	test("test11", much4);
 	setUpOverflowTest("test12");
+	setUpFullscreenTest("test13");
 });

--- a/test/tests.html
+++ b/test/tests.html
@@ -9,10 +9,13 @@
 	#test10 { position: relative; }
 	#test10 .inner { position: absolute; left: 50px; right: 50px; top: 50px; bottom: 50px; background: #ccc; }
 
-	#test12 { border: none;  }
-
 	#flourish-popup-11 .flourish-popup-svg g { fill: rgba(0,0,0,0.9); }
 	#flourish-popup-11 .flourish-popup-content { color: white; }
+
+	#test12 { border: none;  }
+
+	#flourish-popup-13 { pointer-events: all;  }
+	#flourish-popup-13 #fullscreen-test { background: white; }
 </style>
 </head>
 <body>
@@ -62,5 +65,8 @@
 
 	<p>This popup should not cause the page to become horizontally scrollable. Making the window narrower and then clicking the button again should reposition the popup at the right of the window, without leaving any excess scrollable space to the right.</p>
 	<div class="test" id="test12"></div>
+
+	<p>It should be possible to fullscreen an element of a popup, even if the popup is redrawn on window resize.</p>
+	<div class="test" id="test13"></div>
 </body>
 </html>


### PR DESCRIPTION
Make it possible to full-screen an element of a popup. We noticed this with a `<video>` element in a popup, but it’s a generic problem with anything that could be made full screen.

The problem is that redrawing a popup rebuilds its content from scratch, and it’s common in applications of this component to redraw popups on window resize - which is triggered by going full-screen.

Fixes #19.
