### PR TITLE
Improve performance of repeated calls to popup.hide()

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+# 2.1.3
+
+* Only hide the popup once when calling .hide() multiple times in a row.
+* Hide the constrainer element when the popup is hidden.
+
 # 2.1.2
 
 * Include the correct version number in the VERSION property

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@flourish/popup",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flourish/popup",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Popup UI component",
   "main": "popup.js",
   "module": "src/index.js",

--- a/src/draw.js
+++ b/src/draw.js
@@ -59,6 +59,7 @@ export default function Popup_draw() {
 	content = el.querySelector(".flourish-popup-content");
 
 	s.display = "block";
+	popup._getConstrainer().style.display = "block";
 	content.style.maxWidth = maxContentWidth(cb) + "px";
 	if (popup._inner_html != popup._html) {
 		content.innerHTML = popup._inner_html = popup._html;

--- a/src/draw.js
+++ b/src/draw.js
@@ -19,6 +19,8 @@ function positionBox(dir, s, path, w, h, x, y, clientX, clientY, cb) {
 export default function Popup_draw() {
 	var popup = this;
 
+	popup.is_visible = true;
+
 	function maxContentWidth(cb) {
 		if (popup._maxWidth.match(/^\d+(?:\.\d+)?%$/)) {
 			return cb.width * parseFloat(popup._maxWidth) / 100;

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ var OPTIONS = {
 
 function Popup() {
 	this.unique_id = next_unique_id++;
+	this.is_visible = true;
 
 	for (var k in OPTIONS) this["_" + k] = OPTIONS[k];
 
@@ -99,6 +100,8 @@ Popup.prototype._resizeConstrainer = Popup__resizeConstrainer;
 Popup.prototype.draw = Popup_draw;
 
 Popup.prototype.hide = function Popup_hide() {
+	if (!this.is_visible) return this;
+	this.is_visible = false;
 	this._getElement().style.display = "none";
 	return this;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -103,6 +103,7 @@ Popup.prototype.hide = function Popup_hide() {
 	if (!this.is_visible) return this;
 	this.is_visible = false;
 	this._getElement().style.display = "none";
+	this._getConstrainer().style.display = "none";
 	return this;
 }
 


### PR DESCRIPTION
Previously, _resizeConstrainer() was being called every time popup.hide() was being called. This introduces a simple check that prevents popup.hide() from running any heavy code if it's already hidden.

This improves the performance of the popup module in the point map template, which currently calls popup.hide() once per frame. It's possible to make changes in the template to prevent this, but I figure it's better to address this at the module level to prevent it causing performance issues in other templates in the future :)

See also:
https://github.com/kiln/template-3d-point-map/issues/97#issuecomment-662986017